### PR TITLE
Add bug reports link to landing page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,4 +40,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
+    project_urls={
+        "Bug Reports": "https://github.com/tcbegley/dash-google-charts/issues"
+    },
 )


### PR DESCRIPTION
This PR adds a cool little bug reports link to the PyPI landing page for *dash-google-charts*.